### PR TITLE
Added caching to project reading

### DIFF
--- a/src/ReferenceAnalyzer.Core.Tests/ReferencesEditorTests.cs
+++ b/src/ReferenceAnalyzer.Core.Tests/ReferencesEditorTests.cs
@@ -9,17 +9,23 @@ namespace ReferenceAnalyzer.Core.Tests
     public class ReferencesEditorTests
     {
         private readonly ReferencesEditor _sut;
-        private readonly string _projectName;
         private readonly Mock<IProjectAccess> _accessMock;
+        private readonly string _projectPath;
+        private readonly string _noReferencesProjectPath;
+        private readonly string _secondaryProjectPath;
 
         public ReferencesEditorTests()
         {
-            _projectName = "project";
+            var projectDir = @"C:\ProjectDir";
+            _projectPath = $@"{projectDir}\Project.csproj";
+            _secondaryProjectPath = $@"{projectDir}\Project2.csproj";
+            _noReferencesProjectPath = @"C:\TestDir\TestProject.csproj";
             _accessMock = new Mock<IProjectAccess>();
 
-            SetupFile("ProjectAndPackageReferences.csproj", _projectName);
-            SetupFile("Project2.csproj", $@"{_projectName}\..\.\Project2.csproj");
-            SetupFile("Project3.csproj", $@"{_projectName}\..\.\Project3.csproj");
+            SetupFile("ProjectAndPackageReferences.csproj", _projectPath);
+            SetupFile("Project2.csproj", _secondaryProjectPath);
+            SetupFile("Project3.csproj", $@"{projectDir}\Project3.csproj");
+            SetupFile("NoReferences.csproj", _noReferencesProjectPath);
 
             _sut = new ReferencesEditor(_accessMock.Object);
         }
@@ -35,13 +41,101 @@ namespace ReferenceAnalyzer.Core.Tests
         [Fact]
         public void ProjectReferencesRetrieved()
         {
-            _sut.GetReferencedProjects(_projectName).Should().BeEquivalentTo("Project2", "Project3Assembly");
+            _sut.GetReferencedProjects(_projectPath).Should().BeEquivalentTo("Project2", "Project3Assembly");
         }
 
         [Fact]
         public void PackageReferencesRetrieved()
         {
-            _sut.GetReferencedPackages(_projectName).Should().BeEquivalentTo("CommandLineParser");
+            _sut.GetReferencedPackages(_projectPath).Should().BeEquivalentTo("CommandLineParser");
+        }
+
+        [Fact]
+        public void FileContentIsCached()
+        {
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+            _accessMock.Verify(m => m.Read(_noReferencesProjectPath), Times.Once);
+
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+            _accessMock.Verify(m => m.Read(_noReferencesProjectPath), Times.Once);
+        }
+
+        [Fact]
+        public void CacheCanBeInvalidated()
+        {
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+            _accessMock.Verify(m => m.Read(_noReferencesProjectPath), Times.Once);
+
+            _sut.InvalidateCache();
+
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+            _accessMock.Verify(m => m.Read(_noReferencesProjectPath), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void SavingInvalidatesCache()
+        {
+            _sut.GetReferencedProjects(_projectPath);
+            _sut.RemoveReferencedProjects(_projectPath, new []{"Project3Assembly"});
+
+            _sut.GetReferencedProjects(_projectPath);
+
+            _accessMock.Verify(m => m.Read(_projectPath), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void SavingInvalidatesOnlyCorrectProject()
+        {
+
+            _sut.GetReferencedProjects(_projectPath);
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+            _sut.RemoveReferencedProjects(_projectPath, new[] { "Project3Assembly" });
+
+            _sut.GetReferencedProjects(_projectPath);
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+
+            _accessMock.Verify(m => m.Read(_projectPath), Times.Exactly(2));
+            _accessMock.Verify(m => m.Read(_noReferencesProjectPath), Times.Once);
+        }
+
+        [Fact]
+        public void CacheWorksForMultipleFiles()
+        {
+            _sut.GetReferencedProjects(_projectPath);
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+
+            _sut.GetReferencedProjects(_projectPath);
+            _sut.GetReferencedProjects(_noReferencesProjectPath);
+
+            _accessMock.Verify(m => m.Read(_projectPath), Times.Once);
+            _accessMock.Verify(m => m.Read(_noReferencesProjectPath), Times.Once);
+        }
+
+        [Fact]
+        public void CacheWorksForRelativePaths()
+        {
+            var testName = @"C:\TestDir\TestName.csproj";
+            SetupFile("NoReferences.csproj", testName);
+
+            _sut.GetReferencedProjects(testName);
+            _sut.GetReferencedProjects(@"C:\TestDir\..\TestDir\TestName.csproj");
+            _sut.GetReferencedProjects(@"C:\AnotherDir\..\TestDir\TestName.csproj");
+
+            _accessMock.Verify(m => m.Read(testName));
+            _accessMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void DirectAndIndirectAccessAreCached()
+        {
+            _sut.GetReferencedProjects(_projectPath);
+
+            _accessMock.Verify(m => m.Read(_projectPath), Times.Once);
+            _accessMock.Verify(m => m.Read(_secondaryProjectPath), Times.Once);
+
+            _sut.GetReferencedProjects(_secondaryProjectPath);
+
+            _accessMock.Verify(m => m.Read(_secondaryProjectPath), Times.Once);
         }
     }
 }

--- a/src/ReferenceAnalyzer.Core.Tests/TestFiles/NoReferences.csproj
+++ b/src/ReferenceAnalyzer.Core.Tests/TestFiles/NoReferences.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/ReferenceAnalyzer.Core/ProjectEdit/CachedProjectAccess.cs
+++ b/src/ReferenceAnalyzer.Core/ProjectEdit/CachedProjectAccess.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace ReferenceAnalyzer.Core.ProjectEdit
+{
+    public class CachedProjectAccess
+    {
+        private readonly IProjectAccess _projectAccess;
+        private readonly Dictionary<string, string> _cache;
+
+        public CachedProjectAccess(IProjectAccess projectAccess)
+        {
+            _projectAccess = projectAccess;
+            _cache = new Dictionary<string, string>();
+        }
+
+        public string Read(string path)
+        {
+            path = Path.GetFullPath(path);
+            if (!_cache.ContainsKey(path))
+                _cache[path] = _projectAccess.Read(path);
+
+            return _cache[path];
+        }
+
+        public void Write(string path, string content)
+        {
+            _cache.Remove(path);
+        }
+
+        public void Invalidate()
+        {
+            _cache.Clear();
+        }
+    }
+}

--- a/src/ReferenceAnalyzer.Core/ProjectEdit/IReferencesEditor.cs
+++ b/src/ReferenceAnalyzer.Core/ProjectEdit/IReferencesEditor.cs
@@ -8,5 +8,6 @@ namespace ReferenceAnalyzer.Core.ProjectEdit
         IEnumerable<string> GetReferencedPackages(string projectPath);
         void RemoveReferencedProjects(string projectPath, IEnumerable<string> projects);
         string? GetOutputAssemblyName(string projectPath);
+        void InvalidateCache();
     }
 }

--- a/src/ReferenceAnalyzer.Core/ReferenceAnalyzer.cs
+++ b/src/ReferenceAnalyzer.Core/ReferenceAnalyzer.cs
@@ -68,6 +68,8 @@ namespace ReferenceAnalyzer.Core
             ProgressReporter.Report(IndefiniteProgress);
             token.Register(() => ProgressReporter.Report(0));
 
+            _editor.InvalidateCache();
+
             using var workspace = MSBuildWorkspace.Create(BuildProperties);
             workspace.SkipUnrecognizedProjects = true;
 


### PR DESCRIPTION
This will help avoid unnecessary memory allocations which in turn will improve performance. Cache is invalidated on solution load and saving of modified project files.